### PR TITLE
Nextcloud refactoring

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,12 +10,15 @@ HTTP_PASSWORD='mypassword_encoded' # Keep these simple quotes!
 PGID=1000
 PUID=1000
 
+# Database (for Owncloud)
+MYSQL_ROOT_PASSWORD=h4ckMePleAse889912101
+MYSQL_DATABASE=nextcloud
+MYSQL_USER=nextcloud
+MYSQL_PASSWORD=h4ckMePleAse4256718
+
 # Nextcloud
 NEXTCLOUD_ADMIN_USER=admin
-NEXTCLOUD_ADMIN_PASSWORD=nextcloud_admin_password
-NEXTCLOUD_DB_NAME=nextcloud_db_name
-NEXTCLOUD_DB_USER=nextcloud
-NEXTCLOUD_DB_PASSWORD=nextcloud_db_password
+NEXTCLOUD_ADMIN_PASSWORD=h4ckMePleAse873214668
 
 # Portainer
 PORTAINER_ADMIN_PASSWORD=h4ckMePleAse

--- a/.env.sample
+++ b/.env.sample
@@ -2,6 +2,9 @@
 TRAEFIK_DOMAIN=mydomain.com
 ACME_MAIL=my-email@my-provider.com
 
+# General settings
+TZ="Europe/Paris"
+
 # HTTP Auth
 HTTP_USER=myuser
 HTTP_PASSWORD='mypassword_encoded' # Keep these simple quotes!

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ seedbox and personal media server.
 | Jackett              | jackett.yourdomain.com     | [linuxserver/jackett](https://hub.docker.com/r/linuxserver/jackett)    | *latest*                | Tracker indexer     |
 | JDownloader          | jdownloader.yourdomain.com | [jlesage/jdownloader-2](https://hub.docker.com/r/jlesage/jdownloader-2)| *latest*                | Direct downloader   |
 | Tautulli (plexPy)    | tautulli.yourdomain.com    | [linuxserver/tautulli](https://hub.docker.com/r/linuxserver/tautulli)  | *latest*                | Plex stats and admin|
-| NextCloud            | nextcloud.yourdomain.com   | [wonderfall/nextcloud](https://hub.docker.com/r/wonderfall/nextcloud)  | *latest*                | Files management    |
+| NextCloud            | nextcloud.yourdomain.com   | [linuxserver/nextcloud](https://hub.docker.com/r/linuxserver/nextcloud)  | *latest*                | Files management    |
+| NextCloud-db (MariaDB) | not reachable   | [mariadb](https://hub.docker.com/r/_/mariadb)  | *10*                | DB for Nextcloud    |
 | Portainer            | portainer.yourdomain.com   | [portainer/portainer](https://hub.docker.com/r/portainer/portainer)    | *latest*                | Container management|
 | Netdata              | netdata.yourdomain.com     | [netdata/netdata](https://hub.docker.com/r/netdata/netdata)            | *latest*                | Server monitoring   |
 | Duplicati            | duplicati.yourdomain.com   | [linuxserver/duplicati](https://hub.docker.com/r/linuxserver/duplicati)| *latest*                | Backups             |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -243,6 +243,8 @@ services:
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.nextcloud.rule=Host(`nextcloud.${TRAEFIK_DOMAIN}`)"
+            - "traefik.http.services.nextcloud-seedbox.loadbalancer.server.scheme=https"
+            - "traefik.http.services.nextcloud-seedbox.loadbalancer.server.port=443"
 
     portainer:
         image: portainer/portainer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -242,9 +242,18 @@ services:
             - config:/seedbox-config
         labels:
             - "traefik.enable=true"
-            - "traefik.http.routers.nextcloud.rule=Host(`nextcloud.${TRAEFIK_DOMAIN}`)"
-            - "traefik.http.services.nextcloud-seedbox.loadbalancer.server.scheme=https"
-            - "traefik.http.services.nextcloud-seedbox.loadbalancer.server.port=443"
+            #- "traefik.http.routers.nextcloud.rule=Host(`nextcloud.${TRAEFIK_DOMAIN}`)"
+            #- "traefik.http.services.nextcloud-seedbox.loadbalancer.server.scheme=https"
+            #- "traefik.http.services.nextcloud-seedbox.loadbalancer.server.port=443"
+            ## TCP Routers
+            - "traefik.tcp.routers.nextcloud-tcp.entrypoints=https"
+            - "traefik.tcp.routers.nextcloud-tcp.rule=HostSNI(`nextcloud.${TRAEFIK_DOMAIN}`)"
+            - "traefik.tcp.routers.nextcloud-tcp.tls=true"
+            - "traefik.tcp.routers.nextcloud-tcp.tls.certresolver=le"
+            - "traefik.tcp.routers.nextcloud-tcp.tls.passthrough=true"
+            ## TCP Services
+            - "traefik.tcp.routers.nextcloud-tcp.service=nextcloud-tcp-svc"
+            - "traefik.tcp.services.nextcloud-tcp-svc.loadbalancer.server.port=443"
 
     portainer:
         image: portainer/portainer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -243,18 +243,18 @@ services:
             - nextcloudcertificates:/config/keys
         labels:
             - "traefik.enable=true"
-            #- "traefik.http.routers.nextcloud.rule=Host(`nextcloud.${TRAEFIK_DOMAIN}`)"
-            #- "traefik.http.services.nextcloud-seedbox.loadbalancer.server.scheme=https"
-            #- "traefik.http.services.nextcloud-seedbox.loadbalancer.server.port=443"
-            ## TCP Routers
-            - "traefik.tcp.routers.nextcloud-tcp.entrypoints=secure"
-            - "traefik.tcp.routers.nextcloud-tcp.rule=HostSNI(`nextcloud.${TRAEFIK_DOMAIN}`)"
-            - "traefik.tcp.routers.nextcloud-tcp.tls=true"
-            - "traefik.tcp.routers.nextcloud-tcp.tls.certresolver=le"
-            - "traefik.tcp.routers.nextcloud-tcp.tls.passthrough=true"
-            ## TCP Services
-            - "traefik.tcp.routers.nextcloud-tcp.service=nextcloud-tcp-svc"
-            - "traefik.tcp.services.nextcloud-tcp-svc.loadbalancer.server.port=443"
+            - "traefik.http.routers.nextcloud.rule=Host(`nextcloud.${TRAEFIK_DOMAIN}`)"
+            - "traefik.http.services.nextcloud-seedbox.loadbalancer.server.scheme=https"
+            - "traefik.http.services.nextcloud-seedbox.loadbalancer.server.port=443"
+            # ## TCP Routers
+            # - "traefik.tcp.routers.nextcloud-tcp.entrypoints=secure"
+            # - "traefik.tcp.routers.nextcloud-tcp.rule=HostSNI(`nextcloud.${TRAEFIK_DOMAIN}`)"
+            # - "traefik.tcp.routers.nextcloud-tcp.tls=true"
+            # - "traefik.tcp.routers.nextcloud-tcp.tls.certresolver=le"
+            # - "traefik.tcp.routers.nextcloud-tcp.tls.passthrough=true"
+            # ## TCP Services
+            # - "traefik.tcp.routers.nextcloud-tcp.service=nextcloud-tcp-svc"
+            # - "traefik.tcp.services.nextcloud-tcp-svc.loadbalancer.server.port=443"
 
     certdumper:
         image: humenius/traefik-certs-dumper:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,6 +222,7 @@ services:
             - nextcloud-db
         image: nextcloud:20
         container_name: nextcloud
+        user: ${PUID}:${PGID}
         restart: always
         environment:
             - MYSQL_HOST="nextcloud-db"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,12 +220,9 @@ services:
     nextcloud:
         depends_on:
             - nextcloud-db
-        image: nextcloud:20
+        image: linuxserver/nextcloud
         container_name: nextcloud
-        user: ${PUID}:${PGID}
         restart: always
-        sysctls:
-            - net.ipv4.ip_unprivileged_port_start=0
         environment:
             - MYSQL_HOST="nextcloud-db"
             - MYSQL_DATABASE=${MYSQL_DATABASE}
@@ -234,18 +231,18 @@ services:
             - NEXTCLOUD_ADMIN_USER=${NEXTCLOUD_ADMIN_USER}
             - NEXTCLOUD_ADMIN_PASSWORD=${NEXTCLOUD_ADMIN_PASSWORD}
             - NEXTCLOUD_TRUSTED_DOMAINS="nextcloud.${TRAEFIK_DOMAIN}"
-            - APACHE_RUN_USER=${PUID}
-            - APACHE_RUN_GROUP=${PGID}
-            - TZ=Europe/Paris
             - DOMAIN=nextcloud.${TRAEFIK_DOMAIN}
+            - GID=${PGID}
+            - UID=${PUID}
+            - TZ=Europe/Paris
         volumes:
-            - confignextcloud:/var/www/html/
+            - confignextcloud:/config
+            - nextclouddata:/data
             - torrents:/torrents
             - config:/seedbox-config
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.nextcloud.rule=Host(`nextcloud.${TRAEFIK_DOMAIN}`)"
-            - "traefik.http.services.nextcloud-seedbox.loadbalancer.server.port=80"
 
     portainer:
         image: portainer/portainer
@@ -353,6 +350,10 @@ volumes:
         driver: local-persist
         driver_opts:
             mountpoint: /data/config/nextcloud
+    netclouddata:
+        driver: local-persist
+        driver_opts:
+            mountpoint: /data/config/nextcloud-data
     torrents:
         driver: local-persist
         driver_opts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -211,7 +211,7 @@ services:
             - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
             - MYSQL_DATABASE=${MYSQL_DATABASE}
             - MYSQL_USER=${MYSQL_USER}
-            - MYSQL_PASSWORD=${MYSQL_PASSWORD} 
+            - MYSQL_PASSWORD=${MYSQL_PASSWORD}
         volumes: 
             - nextclouddb:/var/lib/mysql
         labels:
@@ -224,6 +224,8 @@ services:
         container_name: nextcloud
         user: ${PUID}:${PGID}
         restart: always
+        sysctls:
+            - net.ipv4.ip_unprivileged_port_start=0
         environment:
             - MYSQL_HOST="nextcloud-db"
             - MYSQL_DATABASE=${MYSQL_DATABASE}
@@ -232,6 +234,8 @@ services:
             - NEXTCLOUD_ADMIN_USER=${NEXTCLOUD_ADMIN_USER}
             - NEXTCLOUD_ADMIN_PASSWORD=${NEXTCLOUD_ADMIN_PASSWORD}
             - NEXTCLOUD_TRUSTED_DOMAINS="nextcloud.${TRAEFIK_DOMAIN}"
+            - APACHE_RUN_USER=${PUID}
+            - APACHE_RUN_GROUP=${PGID}
             - TZ=Europe/Paris
             - DOMAIN=nextcloud.${TRAEFIK_DOMAIN}
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -246,7 +246,7 @@ services:
             #- "traefik.http.services.nextcloud-seedbox.loadbalancer.server.scheme=https"
             #- "traefik.http.services.nextcloud-seedbox.loadbalancer.server.port=443"
             ## TCP Routers
-            - "traefik.tcp.routers.nextcloud-tcp.entrypoints=https"
+            - "traefik.tcp.routers.nextcloud-tcp.entrypoints=secure"
             - "traefik.tcp.routers.nextcloud-tcp.rule=HostSNI(`nextcloud.${TRAEFIK_DOMAIN}`)"
             - "traefik.tcp.routers.nextcloud-tcp.tls=true"
             - "traefik.tcp.routers.nextcloud-tcp.tls.certresolver=le"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ services:
         image: traefik
         container_name: traefik
         restart: always
-        command: --certificatesresolvers.le.acme.email=${ACME_MAIL}
+        command: 
+            - --certificatesresolvers.le.acme.email=${ACME_MAIL}
         ports:
             - "80:80"
             - "443:443"
@@ -13,6 +14,8 @@ services:
             - /var/run/docker.sock:/var/run/docker.sock
             - ./traefik:/etc/traefik:ro
             - configtraefik:/config:ro
+        environment:
+            - TZ=${TZ}
         labels:
             - "traefik.enable=true"
             # Docker labels for enabling Traefik dashboard
@@ -31,7 +34,7 @@ services:
         environment:
             - PGID=${PGID}
             - PUID=${PUID}
-            - TZ=Europe/Paris
+            - TZ=${TZ}
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.deluge.rule=Host(`deluge.${TRAEFIK_DOMAIN}`)"
@@ -54,7 +57,7 @@ services:
         environment:
             - PGID=${PGID}
             - PUID=${PUID}
-            - TZ=Europe/Paris
+            - TZ=${TZ}
             - VERSION=latest
         labels:
             - "traefik.enable=true"
@@ -72,7 +75,7 @@ services:
         environment:
             - PGID=${PGID}
             - PUID=${PUID}
-            - TZ=Europe/Paris
+            - TZ=${TZ}
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.jackett.rule=Host(`jackett.${TRAEFIK_DOMAIN}`)"
@@ -89,7 +92,7 @@ services:
         environment:
             - PGID=${PGID}
             - PUID=${PUID}
-            - TZ=Europe/Paris
+            - TZ=${TZ}
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.sonarr.rule=Host(`sonarr.${TRAEFIK_DOMAIN}`)"
@@ -106,7 +109,7 @@ services:
         environment:
             - PGID=${PGID}
             - PUID=${PUID}
-            - TZ=Europe/Paris
+            - TZ=${TZ}
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.radarr.rule=Host(`radarr.${TRAEFIK_DOMAIN}`)"
@@ -122,7 +125,7 @@ services:
         environment:
             - PGID=${PGID}
             - PUID=${PUID}
-            - TZ=Europe/Paris
+            - TZ=${TZ}
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.bazarr.rule=Host(`bazarr.${TRAEFIK_DOMAIN}`)"
@@ -138,7 +141,7 @@ services:
         environment:
             - PGID=${PGID}
             - PUID=${PUID}
-            - TZ=Europe/Paris
+            - TZ=${TZ}
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.lidarr.rule=Host(`lidarr.${TRAEFIK_DOMAIN}`)"
@@ -154,7 +157,7 @@ services:
         environment:
             - PGID=${PGID}
             - PUID=${PUID}
-            - TZ=Europe/Paris
+            - TZ=${TZ}
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.tautulli.rule=Host(`tautulli.${TRAEFIK_DOMAIN}`)"
@@ -169,38 +172,12 @@ services:
         environment:
             - USER_ID=${PUID}
             - GROUP_ID=${PGID}
-            - TZ=Europe/Paris
+            - TZ=${TZ}
         labels:
             - "traefik.enable=true"
             - "traefik.http.services.jdownloader-seedbox.loadbalancer.server.port=5800"
             - "traefik.http.routers.jdownloader.rule=Host(`jdownloader.${TRAEFIK_DOMAIN}`)"
             - "traefik.http.routers.jdownloader.middlewares=common-auth@file"
-
-    # nextcloud:
-    #     image: wonderfall/nextcloud
-    #     container_name: nextcloud
-    #     restart: always
-    #     volumes:
-    #         - confignextcloud:/config
-    #         - nextclouddata:/data
-    #         - torrents:/torrents
-    #         - config:/seedbox-config
-    #     environment:
-    #         - GID=${PGID}
-    #         - UID=${PUID}
-    #         - TZ=Europe/Paris
-    #         - ADMIN_USER=${NEXTCLOUD_ADMIN_USER}
-    #         - ADMIN_PASSWORD=${NEXTCLOUD_ADMIN_PASSWORD}
-    #         - DOMAIN=nextcloud.${TRAEFIK_DOMAIN}
-    #         - DB_TYPE=sqlite3
-    #         - DB_NAME=${NEXTCLOUD_DB_NAME}
-    #         - DB_USER=${NEXTCLOUD_DB_USER}
-    #         - DB_PASSWORD=${NEXTCLOUD_DB_PASSWORD}
-    #     labels:
-    #         - "traefik.enable=true"
-    #         - "traefik.http.routers.nextcloud.rule=Host(`nextcloud.${TRAEFIK_DOMAIN}`)"
-    #         - "traefik.http.routers.nextcloud.entrypoints=secure"
-    #         - "traefik.http.routers.nextcloud.tls.certresolver=le"
 
     nextcloud-db:
         image: mariadb:10
@@ -212,11 +189,13 @@ services:
             - MYSQL_DATABASE=${MYSQL_DATABASE}
             - MYSQL_USER=${MYSQL_USER}
             - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+            - TZ=${TZ}
         volumes: 
             - nextclouddb:/var/lib/mysql
         labels:
             - "traefik.enable=false"
 
+    # See init-setup-nextcloud.sh for first install
     nextcloud:
         depends_on:
             - nextcloud-db
@@ -224,17 +203,9 @@ services:
         container_name: nextcloud
         restart: always
         environment:
-            # - MYSQL_HOST="nextcloud-db"
-            # - MYSQL_DATABASE=${MYSQL_DATABASE}
-            # - MYSQL_USER=${MYSQL_USER}
-            # - MYSQL_PASSWORD=${MYSQL_PASSWORD}
-            # - NEXTCLOUD_ADMIN_USER=${NEXTCLOUD_ADMIN_USER}
-            # - NEXTCLOUD_ADMIN_PASSWORD=${NEXTCLOUD_ADMIN_PASSWORD}
-            # - NEXTCLOUD_TRUSTED_DOMAINS="nextcloud.${TRAEFIK_DOMAIN}"
-            # - DOMAIN=nextcloud.${TRAEFIK_DOMAIN}
             - PGID=${PGID}
             - PUID=${PUID}
-            - TZ=Europe/Paris
+            - TZ=${TZ}
         volumes:
             - confignextcloud:/config
             - nextclouddata:/data
@@ -245,28 +216,6 @@ services:
             - "traefik.http.routers.nextcloud.rule=Host(`nextcloud.${TRAEFIK_DOMAIN}`)"
             - "traefik.http.services.nextcloud-seedbox.loadbalancer.server.scheme=https"
             - "traefik.http.services.nextcloud-seedbox.loadbalancer.server.port=443"
-            # ## TCP Routers
-            # - "traefik.tcp.routers.nextcloud-tcp.entrypoints=secure"
-            # - "traefik.tcp.routers.nextcloud-tcp.rule=HostSNI(`nextcloud.${TRAEFIK_DOMAIN}`)"
-            # - "traefik.tcp.routers.nextcloud-tcp.tls=true"
-            # - "traefik.tcp.routers.nextcloud-tcp.tls.certresolver=le"
-            # - "traefik.tcp.routers.nextcloud-tcp.tls.passthrough=true"
-            # ## TCP Services
-            # - "traefik.tcp.routers.nextcloud-tcp.service=nextcloud-tcp-svc"
-            # - "traefik.tcp.services.nextcloud-tcp-svc.loadbalancer.server.port=443"
-
-    # certdumper:
-    #     image: humenius/traefik-certs-dumper:latest
-    #     container_name: traefik_certdumper
-    #     command: --restart-containers nextcloud
-    #     volumes:
-    #         - configtraefik:/traefik:ro
-    #         - nextcloudcertificates:/output:rw
-    #         - /var/run/docker.sock:/var/run/docker.sock:ro
-    #     environment:
-    #         - DOMAIN=nextcloud.${TRAEFIK_DOMAIN}
-    #         - OVERRIDE_UID=${PUID}
-    #         - OVERRIDE_GID=${PGID}
 
     portainer:
         image: portainer/portainer
@@ -306,7 +255,7 @@ services:
         environment:
             - PUID=${PUID}
             - PGID=${PGID}
-            - TZ=Europe/Paris
+            - TZ=${TZ}
         volumes:
             - configduplicati:/config
             - backups:/backups
@@ -378,10 +327,6 @@ volumes:
         driver: local-persist
         driver_opts:
             mountpoint: /data/config/nextcloud-data
-    # nextcloudcertificates:
-    #     driver: local-persist
-    #     driver_opts:
-    #         mountpoint: /data/config/nextcloud-certs
     torrents:
         driver: local-persist
         driver_opts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -232,8 +232,8 @@ services:
             - NEXTCLOUD_ADMIN_PASSWORD=${NEXTCLOUD_ADMIN_PASSWORD}
             - NEXTCLOUD_TRUSTED_DOMAINS="nextcloud.${TRAEFIK_DOMAIN}"
             - DOMAIN=nextcloud.${TRAEFIK_DOMAIN}
-            - GID=${PGID}
-            - UID=${PUID}
+            - PGID=${PGID}
+            - PUID=${PUID}
             - TZ=Europe/Paris
         volumes:
             - confignextcloud:/config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -224,14 +224,14 @@ services:
         container_name: nextcloud
         restart: always
         environment:
-            - MYSQL_HOST="nextcloud-db"
-            - MYSQL_DATABASE=${MYSQL_DATABASE}
-            - MYSQL_USER=${MYSQL_USER}
-            - MYSQL_PASSWORD=${MYSQL_PASSWORD}
-            - NEXTCLOUD_ADMIN_USER=${NEXTCLOUD_ADMIN_USER}
-            - NEXTCLOUD_ADMIN_PASSWORD=${NEXTCLOUD_ADMIN_PASSWORD}
-            - NEXTCLOUD_TRUSTED_DOMAINS="nextcloud.${TRAEFIK_DOMAIN}"
-            - DOMAIN=nextcloud.${TRAEFIK_DOMAIN}
+            # - MYSQL_HOST="nextcloud-db"
+            # - MYSQL_DATABASE=${MYSQL_DATABASE}
+            # - MYSQL_USER=${MYSQL_USER}
+            # - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+            # - NEXTCLOUD_ADMIN_USER=${NEXTCLOUD_ADMIN_USER}
+            # - NEXTCLOUD_ADMIN_PASSWORD=${NEXTCLOUD_ADMIN_PASSWORD}
+            # - NEXTCLOUD_TRUSTED_DOMAINS="nextcloud.${TRAEFIK_DOMAIN}"
+            # - DOMAIN=nextcloud.${TRAEFIK_DOMAIN}
             - PGID=${PGID}
             - PUID=${PUID}
             - TZ=Europe/Paris
@@ -240,7 +240,6 @@ services:
             - nextclouddata:/data
             - torrents:/torrents
             - config:/seedbox-config
-            - nextcloudcertificates:/config/keys
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.nextcloud.rule=Host(`nextcloud.${TRAEFIK_DOMAIN}`)"
@@ -256,18 +255,18 @@ services:
             # - "traefik.tcp.routers.nextcloud-tcp.service=nextcloud-tcp-svc"
             # - "traefik.tcp.services.nextcloud-tcp-svc.loadbalancer.server.port=443"
 
-    certdumper:
-        image: humenius/traefik-certs-dumper:latest
-        container_name: traefik_certdumper
-        command: --restart-containers nextcloud
-        volumes:
-            - configtraefik:/traefik:ro
-            - nextcloudcertificates:/output:rw
-            - /var/run/docker.sock:/var/run/docker.sock:ro
-        environment:
-            - DOMAIN=nextcloud.${TRAEFIK_DOMAIN}
-            - OVERRIDE_UID=${PUID}
-            - OVERRIDE_GID=${PGID}
+    # certdumper:
+    #     image: humenius/traefik-certs-dumper:latest
+    #     container_name: traefik_certdumper
+    #     command: --restart-containers nextcloud
+    #     volumes:
+    #         - configtraefik:/traefik:ro
+    #         - nextcloudcertificates:/output:rw
+    #         - /var/run/docker.sock:/var/run/docker.sock:ro
+    #     environment:
+    #         - DOMAIN=nextcloud.${TRAEFIK_DOMAIN}
+    #         - OVERRIDE_UID=${PUID}
+    #         - OVERRIDE_GID=${PGID}
 
     portainer:
         image: portainer/portainer
@@ -379,10 +378,10 @@ volumes:
         driver: local-persist
         driver_opts:
             mountpoint: /data/config/nextcloud-data
-    nextcloudcertificates:
-        driver: local-persist
-        driver_opts:
-            mountpoint: /data/config/nextcloud-certs
+    # nextcloudcertificates:
+    #     driver: local-persist
+    #     driver_opts:
+    #         mountpoint: /data/config/nextcloud-certs
     torrents:
         driver: local-persist
         driver_opts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,7 @@ services:
             - "traefik.enable=true"
             # Docker labels for enabling Traefik dashboard
             - "traefik.http.routers.traefik.rule=Host(`traefik.${TRAEFIK_DOMAIN}`)"
-            - "traefik.http.routers.traefik.entrypoints=secure"
             - "traefik.http.routers.traefik.service=api@internal"
-            - "traefik.http.routers.traefik.tls.certresolver=le"
             - "traefik.http.routers.traefik.middlewares=common-auth@file"
 
     deluge:
@@ -37,8 +35,6 @@ services:
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.deluge.rule=Host(`deluge.${TRAEFIK_DOMAIN}`)"
-            - "traefik.http.routers.deluge.entrypoints=secure"
-            - "traefik.http.routers.deluge.tls.certresolver=le"
             - "traefik.http.routers.deluge.middlewares=common-auth@file"
 
     plex:
@@ -64,8 +60,6 @@ services:
             - "traefik.enable=true"
             - "traefik.http.services.plex-seedbox.loadbalancer.server.port=32400"
             - "traefik.http.routers.plex.rule=Host(`plex.${TRAEFIK_DOMAIN}`)"
-            - "traefik.http.routers.plex.entrypoints=secure"
-            - "traefik.http.routers.plex.tls.certresolver=le"
 
     jackett:
         image: linuxserver/jackett
@@ -82,8 +76,6 @@ services:
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.jackett.rule=Host(`jackett.${TRAEFIK_DOMAIN}`)"
-            - "traefik.http.routers.jackett.entrypoints=secure"
-            - "traefik.http.routers.jackett.tls.certresolver=le"
             - "traefik.http.routers.jackett.middlewares=common-auth@file"
     
     sonarr:
@@ -101,8 +93,6 @@ services:
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.sonarr.rule=Host(`sonarr.${TRAEFIK_DOMAIN}`)"
-            - "traefik.http.routers.sonarr.entrypoints=secure"
-            - "traefik.http.routers.sonarr.tls.certresolver=le"
             - "traefik.http.routers.sonarr.middlewares=common-auth@file"
 
     radarr:
@@ -120,8 +110,6 @@ services:
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.radarr.rule=Host(`radarr.${TRAEFIK_DOMAIN}`)"
-            - "traefik.http.routers.radarr.entrypoints=secure"
-            - "traefik.http.routers.radarr.tls.certresolver=le"
             - "traefik.http.routers.radarr.middlewares=common-auth@file"
 
     bazarr:
@@ -138,8 +126,6 @@ services:
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.bazarr.rule=Host(`bazarr.${TRAEFIK_DOMAIN}`)"
-            - "traefik.http.routers.bazarr.entrypoints=secure"
-            - "traefik.http.routers.bazarr.tls.certresolver=le"
             - "traefik.http.routers.bazarr.middlewares=common-auth@file"
 
     lidarr:
@@ -156,8 +142,6 @@ services:
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.lidarr.rule=Host(`lidarr.${TRAEFIK_DOMAIN}`)"
-            - "traefik.http.routers.lidarr.entrypoints=secure"
-            - "traefik.http.routers.lidarr.tls.certresolver=le"
             - "traefik.http.routers.lidarr.middlewares=common-auth@file"
 
     tautulli:
@@ -174,8 +158,6 @@ services:
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.tautulli.rule=Host(`tautulli.${TRAEFIK_DOMAIN}`)"
-            - "traefik.http.routers.tautulli.entrypoints=secure"
-            - "traefik.http.routers.tautulli.tls.certresolver=le"
 
     jdownloader:
         image: jlesage/jdownloader-2
@@ -192,8 +174,6 @@ services:
             - "traefik.enable=true"
             - "traefik.http.services.jdownloader-seedbox.loadbalancer.server.port=5800"
             - "traefik.http.routers.jdownloader.rule=Host(`jdownloader.${TRAEFIK_DOMAIN}`)"
-            - "traefik.http.routers.jdownloader.entrypoints=secure"
-            - "traefik.http.routers.jdownloader.tls.certresolver=le"
             - "traefik.http.routers.jdownloader.middlewares=common-auth@file"
 
     # nextcloud:
@@ -228,13 +208,10 @@ services:
         command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
         restart: always
         environment:
-            - MYSQL_RANDOM_ROOT_PASSWORD="yes"
             - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
             - MYSQL_DATABASE=${MYSQL_DATABASE}
             - MYSQL_USER=${MYSQL_USER}
             - MYSQL_PASSWORD=${MYSQL_PASSWORD} 
-            - TZ=Europe/Paris
-            - DOMAIN=nextcloud.${TRAEFIK_DOMAIN}
         volumes: 
             - nextclouddb:/var/lib/mysql
         labels:
@@ -254,6 +231,8 @@ services:
             - NEXTCLOUD_ADMIN_USER=${NEXTCLOUD_ADMIN_USER}
             - NEXTCLOUD_ADMIN_PASSWORD=${NEXTCLOUD_ADMIN_PASSWORD}
             - NEXTCLOUD_TRUSTED_DOMAINS="nextcloud.${TRAEFIK_DOMAIN}"
+            - TZ=Europe/Paris
+            - DOMAIN=nextcloud.${TRAEFIK_DOMAIN}
         volumes:
             - confignextcloud:/var/www/html/
             - torrents:/torrents

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -240,6 +240,7 @@ services:
             - nextclouddata:/data
             - torrents:/torrents
             - config:/seedbox-config
+            - nextcloudcertificates:/config/keys
         labels:
             - "traefik.enable=true"
             #- "traefik.http.routers.nextcloud.rule=Host(`nextcloud.${TRAEFIK_DOMAIN}`)"
@@ -254,6 +255,19 @@ services:
             ## TCP Services
             - "traefik.tcp.routers.nextcloud-tcp.service=nextcloud-tcp-svc"
             - "traefik.tcp.services.nextcloud-tcp-svc.loadbalancer.server.port=443"
+
+    certdumper:
+        image: humenius/traefik-certs-dumper:latest
+        container_name: traefik_certdumper
+        command: --restart-containers nextcloud
+        volumes:
+            - configtraefik:/traefik:ro
+            - nextcloudcertificates:/output:rw
+            - /var/run/docker.sock:/var/run/docker.sock:ro
+        environment:
+            - DOMAIN=nextcloud.${TRAEFIK_DOMAIN}
+            - OVERRIDE_UID=${PUID}
+            - OVERRIDE_GID=${PGID}
 
     portainer:
         image: portainer/portainer
@@ -365,6 +379,10 @@ volumes:
         driver: local-persist
         driver_opts:
             mountpoint: /data/config/nextcloud-data
+    nextcloudcertificates:
+        driver: local-persist
+        driver_opts:
+            mountpoint: /data/config/nextcloud-certs
     torrents:
         driver: local-persist
         driver_opts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -196,31 +196,72 @@ services:
             - "traefik.http.routers.jdownloader.tls.certresolver=le"
             - "traefik.http.routers.jdownloader.middlewares=common-auth@file"
 
+    # nextcloud:
+    #     image: wonderfall/nextcloud
+    #     container_name: nextcloud
+    #     restart: always
+    #     volumes:
+    #         - confignextcloud:/config
+    #         - nextclouddata:/data
+    #         - torrents:/torrents
+    #         - config:/seedbox-config
+    #     environment:
+    #         - GID=${PGID}
+    #         - UID=${PUID}
+    #         - TZ=Europe/Paris
+    #         - ADMIN_USER=${NEXTCLOUD_ADMIN_USER}
+    #         - ADMIN_PASSWORD=${NEXTCLOUD_ADMIN_PASSWORD}
+    #         - DOMAIN=nextcloud.${TRAEFIK_DOMAIN}
+    #         - DB_TYPE=sqlite3
+    #         - DB_NAME=${NEXTCLOUD_DB_NAME}
+    #         - DB_USER=${NEXTCLOUD_DB_USER}
+    #         - DB_PASSWORD=${NEXTCLOUD_DB_PASSWORD}
+    #     labels:
+    #         - "traefik.enable=true"
+    #         - "traefik.http.routers.nextcloud.rule=Host(`nextcloud.${TRAEFIK_DOMAIN}`)"
+    #         - "traefik.http.routers.nextcloud.entrypoints=secure"
+    #         - "traefik.http.routers.nextcloud.tls.certresolver=le"
+
+    nextcloud-db:
+        image: mariadb:10
+        container_name: nextcloud-db
+        command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
+        restart: always
+        environment:
+            - MYSQL_RANDOM_ROOT_PASSWORD="yes"
+            - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+            - MYSQL_DATABASE=${MYSQL_DATABASE}
+            - MYSQL_USER=${MYSQL_USER}
+            - MYSQL_PASSWORD=${MYSQL_PASSWORD} 
+            - TZ=Europe/Paris
+            - DOMAIN=nextcloud.${TRAEFIK_DOMAIN}
+        volumes: 
+            - nextclouddb:/var/lib/mysql
+        labels:
+            - "traefik.enable=false"
+
     nextcloud:
-        image: wonderfall/nextcloud
+        depends_on:
+            - nextcloud-db
+        image: nextcloud:20
         container_name: nextcloud
         restart: always
+        environment:
+            - MYSQL_HOST="nextcloud-db"
+            - MYSQL_DATABASE=${MYSQL_DATABASE}
+            - MYSQL_USER=${MYSQL_USER}
+            - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+            - NEXTCLOUD_ADMIN_USER=${NEXTCLOUD_ADMIN_USER}
+            - NEXTCLOUD_ADMIN_PASSWORD=${NEXTCLOUD_ADMIN_PASSWORD}
+            - NEXTCLOUD_TRUSTED_DOMAINS="nextcloud.${TRAEFIK_DOMAIN}"
         volumes:
-            - confignextcloud:/config
-            - nextclouddata:/data
+            - confignextcloud:/var/www/html/
             - torrents:/torrents
             - config:/seedbox-config
-        environment:
-            - GID=${PGID}
-            - UID=${PUID}
-            - TZ=Europe/Paris
-            - ADMIN_USER=${NEXTCLOUD_ADMIN_USER}
-            - ADMIN_PASSWORD=${NEXTCLOUD_ADMIN_PASSWORD}
-            - DOMAIN=nextcloud.${TRAEFIK_DOMAIN}
-            - DB_TYPE=sqlite3
-            - DB_NAME=${NEXTCLOUD_DB_NAME}
-            - DB_USER=${NEXTCLOUD_DB_USER}
-            - DB_PASSWORD=${NEXTCLOUD_DB_PASSWORD}
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.nextcloud.rule=Host(`nextcloud.${TRAEFIK_DOMAIN}`)"
-            - "traefik.http.routers.nextcloud.entrypoints=secure"
-            - "traefik.http.routers.nextcloud.tls.certresolver=le"
+            - "traefik.http.services.nextcloud-seedbox.loadbalancer.server.port=80"
 
     portainer:
         image: portainer/portainer
@@ -232,8 +273,6 @@ services:
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.portainer.rule=Host(`portainer.${TRAEFIK_DOMAIN}`)"
-            - "traefik.http.routers.portainer.entrypoints=secure"
-            - "traefik.http.routers.portainer.tls.certresolver=le"
 
     netdata:
         image: netdata/netdata
@@ -253,8 +292,6 @@ services:
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.netdata.rule=Host(`netdata.${TRAEFIK_DOMAIN}`)"
-            - "traefik.http.routers.netdata.entrypoints=secure"
-            - "traefik.http.routers.netdata.tls.certresolver=le"
             - "traefik.http.routers.netdata.middlewares=common-auth@file"
 
     duplicati:
@@ -272,8 +309,6 @@ services:
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.duplicati.rule=Host(`duplicati.${TRAEFIK_DOMAIN}`)"
-            - "traefik.http.routers.duplicati.entrypoints=secure"
-            - "traefik.http.routers.duplicati.tls.certresolver=le"
             - "traefik.http.routers.duplicati.middlewares=common-auth@file"
 
 networks: 
@@ -326,14 +361,14 @@ volumes:
         driver: local-persist
         driver_opts:
             mountpoint: /data/config/jdownloader
+    nextclouddb:
+        driver: local-persist
+        driver_opts:
+            mountpoint: /data/nextcloud-db
     confignextcloud:
         driver: local-persist
         driver_opts:
             mountpoint: /data/config/nextcloud
-    nextclouddata:
-        driver: local-persist
-        driver_opts:
-            mountpoint: /data/config/nextcloud-data
     torrents:
         driver: local-persist
         driver_opts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -350,7 +350,7 @@ volumes:
         driver: local-persist
         driver_opts:
             mountpoint: /data/config/nextcloud
-    netclouddata:
+    nextclouddata:
         driver: local-persist
         driver_opts:
             mountpoint: /data/config/nextcloud-data

--- a/init-setup-nextcloud.sh
+++ b/init-setup-nextcloud.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+echo "[$0] Loading variables..."
+source .env
+
+echo "[$0] Installing nextcloud..."
+docker exec -it -u abc -w /config/www/nextcloud \
+  nextcloud bash -c " \
+    php occ maintenance:install \
+      --database \"mysql\" \
+      --database-host \"${MYSQL_DATABASE}\" \
+      --database-name \"nextcloud-db\" \
+      --database-user \"${MYSQL_USER}\" \
+      --database-pass \"${MYSQL_PASSWORD}\" \
+      --admin-user \"${NEXTCLOUD_ADMIN_USER}\" \
+      --admin-pass \"${NEXTCLOUD_ADMIN_PASSWORD}\" \
+      --admin-email \"${ACME_MAIL}\" \
+      --data-dir \"/data\" \
+  "
+
+echo "[$0] Done."

--- a/traefik/traefik.yaml
+++ b/traefik/traefik.yaml
@@ -26,6 +26,9 @@ entryPoints:
       middlewares:
       - security-headers@file
 
+serversTransport:
+  insecureSkipVerify: true
+
 certificatesResolvers:
   le:
     acme:

--- a/traefik/traefik.yaml
+++ b/traefik/traefik.yaml
@@ -26,6 +26,7 @@ entryPoints:
       middlewares:
       - security-headers@file
 
+# Allow self-signed certificates for https backends (nextcloud for example)
 serversTransport:
   insecureSkipVerify: true
 

--- a/traefik/traefik.yaml
+++ b/traefik/traefik.yaml
@@ -1,6 +1,12 @@
 api:
   dashboard: true
 
+# Set Access logs timezone
+accessLog:
+  fields:
+    names:
+      StartUTC: drop
+
 providers:
   docker:
     endpoint: "unix:///var/run/docker.sock"


### PR DESCRIPTION
- Use a production-ready image for Nextcloud (prevents bugs such as infinite loading on login)
- Route traffic from Traefik to Nextcloud bundled Apache https port
- Cosmetic changes
- Init script for Nextcloud (no config via environment in Linuxserver's image)
- Variabilize TZ variables