### PR TITLE
Add internalHost configuration to Traefik service for Plex

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -50,6 +50,7 @@ services:
       rules:
         - host: plex.${TRAEFIK_DOMAIN}
           httpAuth: false
+          internalHost: 172.17.0.1
           internalPort: 32400
   - name: flaresolverr
     enabled: true

--- a/run-seedbox.sh
+++ b/run-seedbox.sh
@@ -425,6 +425,8 @@ EOF
     # If VPN => Traefik rule should redirect to gluetun container
     backendHost=${name}
     [[ ${vpn} == "true" ]] && backendHost="gluetun"
+     internalHost=$(echo $rule | jq -r .internalHost)
+    [[ ${internalHost} != "null" ]] && backendHost=${internalHost}
 
     # Handle custom scheme (default if non-specified is http)
     internalScheme="http"


### PR DESCRIPTION
Plex through traefik has not been working for a while. I believe it is due to Plex running in host mode but traefik looking for plex at http://plex:32400. I have added internalHost configuration for Plex service and updated the run script to properly configure the traefik rules. I have tested this on my setup and it works but my setup is highly customized and a lot different than this repo. So, I advise you to test it for this repo/configuration before accepting. 

This resolves issue #71.